### PR TITLE
feature/search-bar_fixed_issues_with_regular_expression

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -16,11 +16,25 @@ export default function App({ Component, pageProps }) {
     includeScore: true,
     threshold: 0,
     useExtendedSearch: true,
+    ignoreLocation: true,
+    ignoreFieldNorm: true,
+    shouldSort: true,
   });
 
+  function matchesQueryAtWordStart(item, query) {
+    const regex = new RegExp(`\\b${query}`, "i");
+    return (
+      regex.test(item.title) ||
+      item.ingredients.some((ingredient) => regex.test(ingredient))
+    );
+  }
+
   const results = searchQuery ? fuse.search(searchQuery) : [];
+
   const filteredRemedies = searchQuery
-    ? results.map((result) => result.item)
+    ? results
+        .map((result) => result.item)
+        .filter((item) => matchesQueryAtWordStart(item, searchQuery))
     : null;
 
   function handleSearchQuery({ currentTarget = {} }) {
@@ -82,9 +96,8 @@ export default function App({ Component, pageProps }) {
       )
     );
   }
-  
-  
-    function handleEditNotes(remedyId, noteId, updatedNote) {
+
+  function handleEditNotes(remedyId, noteId, updatedNote) {
     setRemedies(
       remedies.map((remedy) =>
         remedy.id === remedyId


### PR DESCRIPTION

We have updated the code with a regular expression and an filtering option for the search result to fix the quality assurance issue that was that when "tea" was entered as a search term the results presented did not show all the teas stored in remedies.json but only some teas and also "thyme steam". 

To get all teas we had to do a Fuse.js search at the beginning of a word or across the entire text corpus, regardless of where 'tea' occurs. To get "Tea for Cold" as well as "Thyme Tea for Cold". To assure to display all teas. The problem remaining was that "thyme steam" was still displayed. So we had to tell Fuse.js "I want "tea" to be at the beginning of any word."

For this, we had to filter the "any occurrence"- results from Fuse.js afterwards. And used a regular expression for that including \b (word boundary followed by searchterm) & i (case insensitivity).
